### PR TITLE
Remove left text alignment in Title component

### DIFF
--- a/src/components/Title.css
+++ b/src/components/Title.css
@@ -30,7 +30,6 @@
     color: var(--secondary-text-color);
     text-shadow: 2px 2px 4px rgba(0, 0, 0, 1);
     margin: 0;
-    text-align: left;
 }
 .title h1 {
     font-size: 3.5rem;


### PR DESCRIPTION
Remove the left text alignment from the Title component to improve layout consistency.